### PR TITLE
Add support for ESP32C6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     needs: pre-commit
     strategy:
       matrix:
-        target: [esp32s3]
+        target: [esp32s3, esp32c6]
         esp_idf_version: [v5.3.1]
         path: ['hx711/examples/get_started']
 

--- a/hx711/src/hx711.cpp
+++ b/hx711/src/hx711.cpp
@@ -28,6 +28,13 @@
 
 static const char* kTag = "HX711";
 
+// Not all clock sources are available on all chips.
+#ifdef CONFIG_IDF_TARGET_ESP32C6
+#define GPTIMER_CLK_SOURCE GPTIMER_CLK_SRC_DEFAULT
+#else  // Fallback.
+#define GPTIMER_CLK_SOURCE GPTIMER_CLK_SRC_APB
+#endif
+
 HX711::HX711(gpio_num_t clock_pin, gpio_num_t data_pin, Mode mode)
     : clock_pin_(clock_pin), data_pin_(data_pin) {
     if (mode == Mode::kChannelA128) {
@@ -67,7 +74,7 @@ HX711::HX711(gpio_num_t clock_pin, gpio_num_t data_pin, Mode mode)
     ESP_ERROR_CHECK(dedic_gpio_new_bundle(&data_config, &data_));
 
     gptimer_config_t timer_conf = {};
-    timer_conf.clk_src = GPTIMER_CLK_SRC_APB;
+    timer_conf.clk_src = GPTIMER_CLK_SOURCE;
     timer_conf.direction = GPTIMER_COUNT_UP;
     timer_conf.resolution_hz = 10000000;  // 10MhZ
     ESP_ERROR_CHECK(gptimer_new_timer(&timer_conf, &gptimer_));


### PR DESCRIPTION
- This PR adds support for using this library with ESP32C6.
- ESP32C6 has a limited set of clock sources compared to ESP32S3.
- Implementation verified on a ESP32C6 with hx711.